### PR TITLE
Fix For Linux.

### DIFF
--- a/crostouchpad/synaptics.c
+++ b/crostouchpad/synaptics.c
@@ -284,7 +284,7 @@ Status
 
 	PSYNA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
-	rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
+	rmi_set_sleep_mode(pDevice, RMI_SLEEP_NORMAL);
 
 	WdfTimerStop(pDevice->Timer, TRUE);
 


### PR DESCRIPTION
Linux cannot get the trackpad out of the Deep Sleep State. Use Normal Sleep instead.

This is all that is needed to fix it. Verified by MrChromebox. Thx.