### PR TITLE
Better (maybe) Linux Fix.

### DIFF
--- a/crostouchpad/synaptics.c
+++ b/crostouchpad/synaptics.c
@@ -261,7 +261,7 @@ Status
 NTSTATUS
 OnD0Exit(
 _In_  WDFDEVICE               FxDevice,
-_In_  WDF_POWER_DEVICE_STATE  FxPreviousState
+_In_  WDF_POWER_DEVICE_STATE  FxTargetState
 )
 /*++
 
@@ -272,7 +272,7 @@ This routine destroys objects needed by the driver.
 Arguments:
 
 FxDevice - a handle to the framework device object
-FxPreviousState - previous power state
+FxTargetState - the target power state
 
 Return Value:
 
@@ -280,11 +280,15 @@ Status
 
 --*/
 {
-	UNREFERENCED_PARAMETER(FxPreviousState);
+	UNREFERENCED_PARAMETER(FxTargetState);
 
 	PSYNA_CONTEXT pDevice = GetDeviceContext(FxDevice);
+	
+	if (FxTargetState <= 4) {
 
-	rmi_set_sleep_mode(pDevice, RMI_SLEEP_NORMAL);
+	rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
+	
+	}
 
 	WdfTimerStop(pDevice->Timer, TRUE);
 

--- a/crostouchpad/synaptics.c
+++ b/crostouchpad/synaptics.c
@@ -284,7 +284,7 @@ Status
 
 	PSYNA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
-	rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
+	rmi_set_sleep_mode(pDevice, RMI_SLEEP_NORMAL);
 
 	WdfTimerStop(pDevice->Timer, TRUE);
 

--- a/crostouchpad/synaptics.c
+++ b/crostouchpad/synaptics.c
@@ -284,7 +284,7 @@ Status
 
 	PSYNA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 	
-	if (FxTargetState <= 4) {
+	if (FxTargetState != 5) {
 
 	rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
 	


### PR DESCRIPTION
I tried a new approach to the Synaptics power state issue based on the understanding (to the best of my ability, not sure if I have this right) that one of the parameters of OnD0Exit is actually the target power state that the device is seeking to go to.

https://msdn.microsoft.com/en-us/library/windows/hardware/ff556803(v=vs.85).aspx

https://github.com/Microsoft/Windows-driver-samples/blob/master/sensors/SimpleDeviceOrientationSensor/device.cpp#L537

MrChromebox has tested this fix, and it seems to work, but I'm not sure if I've just made it so that the check fails every time. The thought was based on the list of power states here:

https://msdn.microsoft.com/en-us/library/windows/hardware/ff552421(v=vs.85).aspx

Hope being that on states 5, 6, or 7 (> 4), the Deep sleep would not be used, and this would allow one to reboot/shut down to Linux and have the touchpad work while still retaining Deep sleep in D3.

I am asking for a review of the reasonability of this approach. I can continue to rework it if I seem to be on the right track. Thx. 

Edit: This has been updated to incorporate the new fix seen in crostouchscreen2.

Edit2: This new fix has been confirmed to work by MrChromebox.