### PR TITLE
synaptics.c: don't set deep sleep on reboot

### DIFF
--- a/crostouchpad/synaptics.c
+++ b/crostouchpad/synaptics.c
@@ -261,7 +261,7 @@ Status
 NTSTATUS
 OnD0Exit(
 _In_  WDFDEVICE               FxDevice,
-_In_  WDF_POWER_DEVICE_STATE  FxPreviousState
+_In_  WDF_POWER_DEVICE_STATE  FxTargetState
 )
 /*++
 
@@ -272,7 +272,7 @@ This routine destroys objects needed by the driver.
 Arguments:
 
 FxDevice - a handle to the framework device object
-FxPreviousState - previous power state
+FxTargetState - target power state
 
 Return Value:
 
@@ -280,11 +280,13 @@ Status
 
 --*/
 {
-	UNREFERENCED_PARAMETER(FxPreviousState);
-
 	PSYNA_CONTEXT pDevice = GetDeviceContext(FxDevice);
 
-	rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
+	/* Don't set deep sleep when rebooting,
+	 * as this breaks the buggy Linux driver */
+	if (FxTargetState != 5) {
+		rmi_set_sleep_mode(pDevice, RMI_SLEEP_DEEP_SLEEP);
+	}
 
 	WdfTimerStop(pDevice->Timer, TRUE);
 


### PR DESCRIPTION
The Linux Synatpics driver doesn't properly reset the
device power state, so don't put into deep sleep on reboot.

Signed-off-by: Matt Devillier <matt.devillier@gmail.com>